### PR TITLE
Fixed issues with certain tooltips being failed to display

### DIFF
--- a/src/main/java/com/snowshock35/jeiintegration/TooltipEventHandler.java
+++ b/src/main/java/com/snowshock35/jeiintegration/TooltipEventHandler.java
@@ -135,8 +135,8 @@ public class TooltipEventHandler {
         }
 
         // Tooltip - Hunger / Saturation
-        if (item.isFood()) {
-            int healVal = Objects.requireNonNull(item.getFood()).getHealing();
+        if (item.isFood() && item.getFood() != null) {
+            int healVal = item.getFood().getHealing();
             float satVal = healVal * (item.getFood().getSaturation() * 2);
 
             ITextComponent foodTooltip = new TranslationTextComponent("tooltip.jeiintegration.hunger")


### PR DESCRIPTION
and in some edge cases crashing the game. Example: Using Alchemistry and JEI integrations, if you create potassium cyanide in a chemical dissolver and hover over it in that GUI, the client crashed.

How to reproduce: Install Alchemistry (plus dependencies Chem Lib and A Lib) and JEI integrations, put a pufferfish in a chemical dissolver and hover over the results.

This change has been tested and fixes that.